### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/Firmware/gps-test/README.md
+++ b/Firmware/gps-test/README.md
@@ -29,7 +29,7 @@ python find_serial_port.py
 
 This will show all available serial ports. Look for something like:
 - macOS: `/dev/tty.usbserial-0001`
-- Linux/Pi: `/dev/ttyAMA4' # We're conected to UART4 Cound be `/dev/ttyUSB0` or `/dev/ttyACM0` if testing
+- Linux/Pi: `/dev/ttyAMA4' # We're connected to UART4. Could be `/dev/ttyUSB0` or `/dev/ttyACM0` if testing
 
 ### Step 2: Edit Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,5 @@ dev = [
 skip = '.git,.gitignore,.gitattributes,*.pdf'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+# ser - conventional pyserial variable name for a serial.Serial instance
+ignore-words-list = 'ser'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,10 @@ dev = [
     "opencv-python>=4.13.0.92",
     "numpy",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.pdf'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
Add codespell configuration and fix existing typos.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred of projects already mostly with a positive feedback
(see the ["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

CI workflow has `permissions` set only to `read` so also should be safe.

## Changes

### Configuration & Infrastructure
- Added `[tool.codespell]` section in `pyproject.toml` with `check-hidden` and a
  minimal `skip` list (`.git,.gitignore,.gitattributes,*.pdf`).
- Added `.github/workflows/codespell.yml` — runs codespell on push and PRs against
  `main`, uses the pinned `codespell-project/actions-codespell@…` action, and has
  `permissions: contents: read` only.

### Domain-Specific Whitelist
- `ser` — the conventional pyserial variable name for a `serial.Serial` instance,
  used 68 times across `Firmware/`. Codespell wanted to "fix" it to `set`.

### Typo Fixes
One line in `Firmware/gps-test/README.md`:

- `conected` → `connected` (non-ambiguous)
- `Cound` → `Could` (ambiguous — picked from context: "Could be `/dev/ttyUSB0`
  or `/dev/ttyACM0` if testing")

Also inserted a period between the two sentences that were run together on the same line.

## Testing

Codespell passes with zero errors after all fixes, both under the default
`--builtin clear,rare` dictionaries and the extended
`--builtin clear,rare,usage,code,names` pass.

---

Generated with [Claude Code](https://claude.com/claude-code) and love to typo-free code.
